### PR TITLE
Abjad Convert Version 0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ This is a monorepo for the Abjad Convert project.
 
 ## Packages
 ### Abajd Convert
-[![Version](https://img.shields.io/badge/version-0.12.0-blue.svg)](https://github.com/amerharb/abjad/tree/abjad-convert/version/0.12.0)
+[![Version](https://img.shields.io/badge/version-0.12.1-blue.svg)](https://github.com/amerharb/abjad/tree/abjad-convert/version/0.12.1)
 [![License: GPLv3](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
-![Coverage](https://raw.githubusercontent.com/amerharb/abjad/abjad-convert/version/0.12.0/packages/abjad-convert/badges/coverage.svg)
-![Github workflow](https://github.com/amerharb/abjad/actions/workflows/lint-test.yaml/badge.svg?branch=abjad-convert/version/0.12.0)
+![Coverage](https://raw.githubusercontent.com/amerharb/abjad/abjad-convert/version/0.12.1/packages/abjad-convert/badges/coverage.svg)
+![Github workflow](https://github.com/amerharb/abjad/actions/workflows/lint-test.yaml/badge.svg?branch=abjad-convert/version/0.12.1)
 <br>
 [README](https://github.com/amerharb/abjad/blob/main/packages/abjad-convert/README.md)
 
 <br>
 
 ### Abjad Web
-[![Version](https://img.shields.io/badge/version-0.12.0-blue.svg)](https://github.com/amerharb/abjad/tree/abjad-web/version/0.12.0)
+[![Version](https://img.shields.io/badge/version-0.12.1-blue.svg)](https://github.com/amerharb/abjad/tree/abjad-web/version/0.12.1)
 <br>
 [README](https://github.com/amerharb/abjad/blob/main/packages/abjad-web/README.md)
 

--- a/packages/abjad-convert/CHANGELOG.md
+++ b/packages/abjad-convert/CHANGELOG.md
@@ -1,6 +1,10 @@
 # abjad-convert Changelog
 <!-- https://keepachangelog.com/en/1.0.0/ -->
 
+## [0.12.1] 2026-06-29
+### Fixed
+- Nabataean letter Taw now maps to the correct code point U+1089E (was U+1089F)
+
 ## [0.12.0] 2025-03-16
 ### Added
 - Support for Hebrew

--- a/packages/abjad-convert/CHANGELOG.md
+++ b/packages/abjad-convert/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Docs
 - Corrected the U+ reference comments for the Hanifi Rohingya digits (were U+10D28–U+10D31; the code points were already correct at U+10D30–U+10D39)
 - Corrected the glyph characters shown in the Old South Arabian letter comments (they showed characters from the Rumi Numeral Symbols block; the code points were already correct)
+- Corrected the glyph characters shown in the Tifinagh Separator Mark and Consonant Joiner comments (the code points were already correct)
 
 ## [0.12.0] 2025-03-16
 ### Added

--- a/packages/abjad-convert/CHANGELOG.md
+++ b/packages/abjad-convert/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Nabataean letter Taw now maps to the correct code point U+1089E (was U+1089F)
 ### Docs
 - Corrected the U+ reference comments for the Hanifi Rohingya digits (were U+10D28–U+10D31; the code points were already correct at U+10D30–U+10D39)
+- Corrected the glyph characters shown in the Old South Arabian letter comments (they showed characters from the Rumi Numeral Symbols block; the code points were already correct)
 
 ## [0.12.0] 2025-03-16
 ### Added

--- a/packages/abjad-convert/CHANGELOG.md
+++ b/packages/abjad-convert/CHANGELOG.md
@@ -4,6 +4,8 @@
 ## [0.12.1] 2026-06-29
 ### Fixed
 - Nabataean letter Taw now maps to the correct code point U+1089E (was U+1089F)
+### Docs
+- Corrected the U+ reference comments for the Hanifi Rohingya digits (were U+10D28–U+10D31; the code points were already correct at U+10D30–U+10D39)
 
 ## [0.12.0] 2025-03-16
 ### Added

--- a/packages/abjad-convert/README.md
+++ b/packages/abjad-convert/README.md
@@ -1,9 +1,9 @@
 # Abjad Convert
 
-[![Version](https://img.shields.io/badge/version-0.12.0-blue.svg)](https://github.com/amerharb/abjad/tree/abjad-convert/version/0.12.0)
+[![Version](https://img.shields.io/badge/version-0.12.1-blue.svg)](https://github.com/amerharb/abjad/tree/abjad-convert/version/0.12.1)
 [![License: GPLv3](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
-![Coverage](https://raw.githubusercontent.com/amerharb/abjad/abjad-convert/version/0.12.0/packages/abjad-convert/badges/coverage.svg)
-![Github workflow](https://github.com/amerharb/abjad/actions/workflows/lint-test.yaml/badge.svg?branch=abjad-convert/version/0.12.0)
+![Coverage](https://raw.githubusercontent.com/amerharb/abjad/abjad-convert/version/0.12.1/packages/abjad-convert/badges/coverage.svg)
+![Github workflow](https://github.com/amerharb/abjad/actions/workflows/lint-test.yaml/badge.svg?branch=abjad-convert/version/0.12.1)
 
 **abjad-convert** is a package for converting Abjad alphabets phonetically.
 

--- a/packages/abjad-convert/package.json
+++ b/packages/abjad-convert/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "abjad-convert",
-	"version": "0.12.0-masked",
+	"version": "0.12.1-next.0",
 	"main": "dist/src/index.js",
 	"types": "dist/src/index.d.ts",
 	"files": [

--- a/packages/abjad-convert/src/scripts/hanifiRohingya/letters.ts
+++ b/packages/abjad-convert/src/scripts/hanifiRohingya/letters.ts
@@ -46,16 +46,16 @@ const letters = [
 	String.fromCodePoint(0x10D26), /** #38 𐴦 U+10D26 HANIFI ROHINGYA SIGN TANA */
 	String.fromCodePoint(0x10D27), /** #39 𐴧 U+10D27 HANIFI ROHINGYA SIGN TASSI */
 
-	String.fromCodePoint(0x10D30), /** #40 𐴰 U+10D28 HANIFI ROHINGYA DIGIT ZERO */
-	String.fromCodePoint(0x10D31), /** #41 𐴱 U+10D29 HANIFI ROHINGYA DIGIT ONE */
-	String.fromCodePoint(0x10D32), /** #42 𐴲 U+10D2A HANIFI ROHINGYA DIGIT TWO */
-	String.fromCodePoint(0x10D33), /** #43 𐴳 U+10D2B HANIFI ROHINGYA DIGIT THREE */
-	String.fromCodePoint(0x10D34), /** #44 𐴴 U+10D2C HANIFI ROHINGYA DIGIT FOUR */
-	String.fromCodePoint(0x10D35), /** #45 𐴵 U+10D2D HANIFI ROHINGYA DIGIT FIVE */
-	String.fromCodePoint(0x10D36), /** #46 𐴶 U+10D2E HANIFI ROHINGYA DIGIT SIX */
-	String.fromCodePoint(0x10D37), /** #47 𐴷 U+10D2F HANIFI ROHINGYA DIGIT SEVEN */
-	String.fromCodePoint(0x10D38), /** #48 𐴸 U+10D30 HANIFI ROHINGYA DIGIT EIGHT */
-	String.fromCodePoint(0x10D39), /** #49 𐴹 U+10D31 HANIFI ROHINGYA DIGIT NINE */
+	String.fromCodePoint(0x10D30), /** #40 𐴰 U+10D30 HANIFI ROHINGYA DIGIT ZERO */
+	String.fromCodePoint(0x10D31), /** #41 𐴱 U+10D31 HANIFI ROHINGYA DIGIT ONE */
+	String.fromCodePoint(0x10D32), /** #42 𐴲 U+10D32 HANIFI ROHINGYA DIGIT TWO */
+	String.fromCodePoint(0x10D33), /** #43 𐴳 U+10D33 HANIFI ROHINGYA DIGIT THREE */
+	String.fromCodePoint(0x10D34), /** #44 𐴴 U+10D34 HANIFI ROHINGYA DIGIT FOUR */
+	String.fromCodePoint(0x10D35), /** #45 𐴵 U+10D35 HANIFI ROHINGYA DIGIT FIVE */
+	String.fromCodePoint(0x10D36), /** #46 𐴶 U+10D36 HANIFI ROHINGYA DIGIT SIX */
+	String.fromCodePoint(0x10D37), /** #47 𐴷 U+10D37 HANIFI ROHINGYA DIGIT SEVEN */
+	String.fromCodePoint(0x10D38), /** #48 𐴸 U+10D38 HANIFI ROHINGYA DIGIT EIGHT */
+	String.fromCodePoint(0x10D39), /** #49 𐴹 U+10D39 HANIFI ROHINGYA DIGIT NINE */
 ] as const
 
 export const HR = {

--- a/packages/abjad-convert/src/scripts/nabataean/letters.ts
+++ b/packages/abjad-convert/src/scripts/nabataean/letters.ts
@@ -38,7 +38,7 @@ const letters = [
 	String.fromCodePoint(0x1089B), /** #27 𐢛 U+1089B NABATEAEN LETTER Resh */
 	String.fromCodePoint(0x1089C), /** #28 𐢜 U+1089C NABATEAEN LETTER Final Shin */
 	String.fromCodePoint(0x1089D), /** #29 𐢝 U+1089D NABATEAEN LETTER Shin */
-	String.fromCodePoint(0x1089F), /** #30 𐢞 U+1089E NABATEAEN LETTER Taw */
+	String.fromCodePoint(0x1089E), /** #30 𐢞 U+1089E NABATEAEN LETTER Taw */
 ] as const
 
 export const Na = {

--- a/packages/abjad-convert/src/scripts/oldSouthArabian/letters.ts
+++ b/packages/abjad-convert/src/scripts/oldSouthArabian/letters.ts
@@ -5,73 +5,73 @@ import { Abjad } from '../../types'
  * Old South Arabian letters
  */
 const letters = [
-	String.fromCodePoint(0x10A60), /** #0  𐹠 U+10A60 OLD SOUTH ARABIAN LETTER He */
-	String.fromCodePoint(0x10A61), /** #1  𐹡 U+10A61 OLD SOUTH ARABIAN LETTER Lamedh */
-	String.fromCodePoint(0x10A62), /** #2  𐹢 U+10A62 OLD SOUTH ARABIAN LETTER Heth */
-	String.fromCodePoint(0x10A63), /** #3  𐹣 U+10A63 OLD SOUTH ARABIAN LETTER Mem */
-	String.fromCodePoint(0x10A64), /** #4  𐹤 U+10A64 OLD SOUTH ARABIAN LETTER Qoph */
-	String.fromCodePoint(0x10A65), /** #5  𐹥 U+10A65 OLD SOUTH ARABIAN LETTER Waw */
-	String.fromCodePoint(0x10A66), /** #6  𐹦 U+10A66 OLD SOUTH ARABIAN LETTER Shin */
-	String.fromCodePoint(0x10A67), /** #7  𐹧 U+10A67 OLD SOUTH ARABIAN LETTER Resh */
-	String.fromCodePoint(0x10A68), /** #8  𐹨 U+10A68 OLD SOUTH ARABIAN LETTER Beth */
-	String.fromCodePoint(0x10A69), /** #9  𐹩 U+10A69 OLD SOUTH ARABIAN LETTER Taw */
-	String.fromCodePoint(0x10A6A), /** #10 𐹪 U+10A6A OLD SOUTH ARABIAN LETTER Sat */
-	String.fromCodePoint(0x10A6B), /** #11 𐹫 U+10A6B OLD SOUTH ARABIAN LETTER Kaph */
-	String.fromCodePoint(0x10A6C), /** #12 𐹬 U+10A6C OLD SOUTH ARABIAN LETTER Nun */
-	String.fromCodePoint(0x10A6D), /** #13 𐹭 U+10A6D OLD SOUTH ARABIAN LETTER Kheth */
-	String.fromCodePoint(0x10A6E), /** #14 𐹮 U+10A6E OLD SOUTH ARABIAN LETTER Sadhe */
-	String.fromCodePoint(0x10A6F), /** #15 𐹯 U+10A6F OLD SOUTH ARABIAN LETTER Samekh */
-	String.fromCodePoint(0x10A70), /** #16 𐹰 U+10A70 OLD SOUTH ARABIAN LETTER Fe */
-	String.fromCodePoint(0x10A71), /** #17 𐹱 U+10A71 OLD SOUTH ARABIAN LETTER Alef */
-	String.fromCodePoint(0x10A72), /** #18 𐹲 U+10A72 OLD SOUTH ARABIAN LETTER Ayin */
-	String.fromCodePoint(0x10A73), /** #19 𐹳 U+10A73 OLD SOUTH ARABIAN LETTER Dhadhe */
-	String.fromCodePoint(0x10A74), /** #20 𐹴 U+10A74 OLD SOUTH ARABIAN LETTER Gimel */
-	String.fromCodePoint(0x10A75), /** #21 𐹵 U+10A75 OLD SOUTH ARABIAN LETTER Daleth */
-	String.fromCodePoint(0x10A76), /** #22 𐹶 U+10A76 OLD SOUTH ARABIAN LETTER Ghayn */
-	String.fromCodePoint(0x10A77), /** #23 𐹷 U+10A77 OLD SOUTH ARABIAN LETTER Teth */
-	String.fromCodePoint(0x10A78), /** #24 𐹸 U+10A78 OLD SOUTH ARABIAN LETTER Zayn */
-	String.fromCodePoint(0x10A79), /** #25 𐹹 U+10A79 OLD SOUTH ARABIAN LETTER Dhaleth */
-	String.fromCodePoint(0x10A7A), /** #26 𐹺 U+10A7A OLD SOUTH ARABIAN LETTER Yodh */
-	String.fromCodePoint(0x10A7B), /** #27 𐹻 U+10A7B OLD SOUTH ARABIAN LETTER Thaw */
-	String.fromCodePoint(0x10A7C), /** #28 𐹼 U+10A7C OLD SOUTH ARABIAN LETTER Theth */
-	String.fromCodePoint(0x10A7D), /** #29 𐹽 U+10A7D OLD SOUTH ARABIAN NUMBER ONE */
-	String.fromCodePoint(0x10A7E), /** #30 𐹾 U+10A7E OLD SOUTH ARABIAN NUMBER FIFTY */
-	String.fromCodePoint(0x10A7F), /** #31 𐹿 U+10A7F OLD SOUTH ARABIAN NUMERIC INDICATOR */
+	String.fromCodePoint(0x10A60), /** #0  𐩠 U+10A60 OLD SOUTH ARABIAN LETTER He */
+	String.fromCodePoint(0x10A61), /** #1  𐩡 U+10A61 OLD SOUTH ARABIAN LETTER Lamedh */
+	String.fromCodePoint(0x10A62), /** #2  𐩢 U+10A62 OLD SOUTH ARABIAN LETTER Heth */
+	String.fromCodePoint(0x10A63), /** #3  𐩣 U+10A63 OLD SOUTH ARABIAN LETTER Mem */
+	String.fromCodePoint(0x10A64), /** #4  𐩤 U+10A64 OLD SOUTH ARABIAN LETTER Qoph */
+	String.fromCodePoint(0x10A65), /** #5  𐩥 U+10A65 OLD SOUTH ARABIAN LETTER Waw */
+	String.fromCodePoint(0x10A66), /** #6  𐩦 U+10A66 OLD SOUTH ARABIAN LETTER Shin */
+	String.fromCodePoint(0x10A67), /** #7  𐩧 U+10A67 OLD SOUTH ARABIAN LETTER Resh */
+	String.fromCodePoint(0x10A68), /** #8  𐩨 U+10A68 OLD SOUTH ARABIAN LETTER Beth */
+	String.fromCodePoint(0x10A69), /** #9  𐩩 U+10A69 OLD SOUTH ARABIAN LETTER Taw */
+	String.fromCodePoint(0x10A6A), /** #10 𐩪 U+10A6A OLD SOUTH ARABIAN LETTER Sat */
+	String.fromCodePoint(0x10A6B), /** #11 𐩫 U+10A6B OLD SOUTH ARABIAN LETTER Kaph */
+	String.fromCodePoint(0x10A6C), /** #12 𐩬 U+10A6C OLD SOUTH ARABIAN LETTER Nun */
+	String.fromCodePoint(0x10A6D), /** #13 𐩭 U+10A6D OLD SOUTH ARABIAN LETTER Kheth */
+	String.fromCodePoint(0x10A6E), /** #14 𐩮 U+10A6E OLD SOUTH ARABIAN LETTER Sadhe */
+	String.fromCodePoint(0x10A6F), /** #15 𐩯 U+10A6F OLD SOUTH ARABIAN LETTER Samekh */
+	String.fromCodePoint(0x10A70), /** #16 𐩰 U+10A70 OLD SOUTH ARABIAN LETTER Fe */
+	String.fromCodePoint(0x10A71), /** #17 𐩱 U+10A71 OLD SOUTH ARABIAN LETTER Alef */
+	String.fromCodePoint(0x10A72), /** #18 𐩲 U+10A72 OLD SOUTH ARABIAN LETTER Ayin */
+	String.fromCodePoint(0x10A73), /** #19 𐩳 U+10A73 OLD SOUTH ARABIAN LETTER Dhadhe */
+	String.fromCodePoint(0x10A74), /** #20 𐩴 U+10A74 OLD SOUTH ARABIAN LETTER Gimel */
+	String.fromCodePoint(0x10A75), /** #21 𐩵 U+10A75 OLD SOUTH ARABIAN LETTER Daleth */
+	String.fromCodePoint(0x10A76), /** #22 𐩶 U+10A76 OLD SOUTH ARABIAN LETTER Ghayn */
+	String.fromCodePoint(0x10A77), /** #23 𐩷 U+10A77 OLD SOUTH ARABIAN LETTER Teth */
+	String.fromCodePoint(0x10A78), /** #24 𐩸 U+10A78 OLD SOUTH ARABIAN LETTER Zayn */
+	String.fromCodePoint(0x10A79), /** #25 𐩹 U+10A79 OLD SOUTH ARABIAN LETTER Dhaleth */
+	String.fromCodePoint(0x10A7A), /** #26 𐩺 U+10A7A OLD SOUTH ARABIAN LETTER Yodh */
+	String.fromCodePoint(0x10A7B), /** #27 𐩻 U+10A7B OLD SOUTH ARABIAN LETTER Thaw */
+	String.fromCodePoint(0x10A7C), /** #28 𐩼 U+10A7C OLD SOUTH ARABIAN LETTER Theth */
+	String.fromCodePoint(0x10A7D), /** #29 𐩽 U+10A7D OLD SOUTH ARABIAN NUMBER ONE */
+	String.fromCodePoint(0x10A7E), /** #30 𐩾 U+10A7E OLD SOUTH ARABIAN NUMBER FIFTY */
+	String.fromCodePoint(0x10A7F), /** #31 𐩿 U+10A7F OLD SOUTH ARABIAN NUMERIC INDICATOR */
 ] as const
 
 export const Sa = {
-	He: letters[0], // 𐹠
-	Lamedh: letters[1], // 𐹡
-	Heth: letters[2], // 𐹢
-	Mem: letters[3], // 𐹣
-	Qoph: letters[4], // 𐹤
-	Waw: letters[5], // 𐹥
-	Shin: letters[6], // 𐹦
-	Resh: letters[7], // 𐹧
-	Beth: letters[8], // 𐹨
-	Taw: letters[9], // 𐹩
-	Sat: letters[10], // 𐹪
-	Kaph: letters[11], // 𐹫
-	Nun: letters[12], // 𐹬
-	Kheth: letters[13], // 𐹭
-	Sadhe: letters[14], // 𐹮
-	Samekh: letters[15], // 𐹯
-	Fe: letters[16], // 𐹰
-	Alef: letters[17], // 𐹱
-	Ayin: letters[18], // 𐹲
-	Dhadhe: letters[19], // 𐹳
-	Gimel: letters[20], // 𐹴
-	Daleth: letters[21], // 𐹵
-	Ghayn: letters[22], // 𐹶
-	Teth: letters[23], // 𐹷
-	Zayn: letters[24], // 𐹸
-	Dhaleth: letters[25], // 𐹹
-	Yodh: letters[26], // 𐹺
-	Thaw: letters[27], // 𐹻
-	Theth: letters[28], // 𐹼
-	ONE: letters[29], // 𐹽
-	FIFTY: letters[30], // 𐹾
-	INDICATOR: letters[31], // 𐹿
+	He: letters[0], // 𐩠
+	Lamedh: letters[1], // 𐩡
+	Heth: letters[2], // 𐩢
+	Mem: letters[3], // 𐩣
+	Qoph: letters[4], // 𐩤
+	Waw: letters[5], // 𐩥
+	Shin: letters[6], // 𐩦
+	Resh: letters[7], // 𐩧
+	Beth: letters[8], // 𐩨
+	Taw: letters[9], // 𐩩
+	Sat: letters[10], // 𐩪
+	Kaph: letters[11], // 𐩫
+	Nun: letters[12], // 𐩬
+	Kheth: letters[13], // 𐩭
+	Sadhe: letters[14], // 𐩮
+	Samekh: letters[15], // 𐩯
+	Fe: letters[16], // 𐩰
+	Alef: letters[17], // 𐩱
+	Ayin: letters[18], // 𐩲
+	Dhadhe: letters[19], // 𐩳
+	Gimel: letters[20], // 𐩴
+	Daleth: letters[21], // 𐩵
+	Ghayn: letters[22], // 𐩶
+	Teth: letters[23], // 𐩷
+	Zayn: letters[24], // 𐩸
+	Dhaleth: letters[25], // 𐩹
+	Yodh: letters[26], // 𐩺
+	Thaw: letters[27], // 𐩻
+	Theth: letters[28], // 𐩼
+	ONE: letters[29], // 𐩽
+	FIFTY: letters[30], // 𐩾
+	INDICATOR: letters[31], // 𐩿
 }
 
 export const oldSouthArabian = new Script(

--- a/packages/abjad-convert/src/scripts/tifinagh/letters.ts
+++ b/packages/abjad-convert/src/scripts/tifinagh/letters.ts
@@ -59,8 +59,8 @@ const letters = [
 	String.fromCodePoint(0x2d66), /** #54 ⵦ U+2D66 TIFINAGH LETTER YE */
 	String.fromCodePoint(0x2d67), /** #55 ⵧ U+2D67 TIFINAGH LETTER YO */
 	String.fromCodePoint(0x2d6f), /** #56 ⵯ U+2D6F TIFINAGH MODIFIER LETTER LABIALIZATION MARK */
-	String.fromCodePoint(0x2d70), /** #54 ⵯ U+2D70 TIFINAGH SEPARATOR MARK */
-	String.fromCodePoint(0x2d7f), /** #55 ⵯ U+2D7F TIFINAGH CONSONANT JOINER */
+	String.fromCodePoint(0x2d70), /** #54 ⵰ U+2D70 TIFINAGH SEPARATOR MARK */
+	String.fromCodePoint(0x2d7f), /** #55 ⵿ U+2D7F TIFINAGH CONSONANT JOINER */
 ] as const
 
 export const Ti = {


### PR DESCRIPTION
- Nabataean letter Taw now maps to the correct code point U+1089E (was U+1089F)